### PR TITLE
Fix urlpatterns to no longer use deprecated patterns() syntax

### DIFF
--- a/pinax/wiki/urls.py
+++ b/pinax/wiki/urls.py
@@ -1,20 +1,18 @@
 import os
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .conf import settings
 from .views import index, page, edit, file_download, file_upload
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^file-download/(\d+)/([^/]+)$", file_download, name="pinax_wiki_file_download"),
     url(r"^file-upload/$", file_upload, name="pinax_wiki_file_upload")
-)
+]
 
 for binder in settings.PINAX_WIKI_BINDERS:
-    urlpatterns += patterns(
-        "",
+    urlpatterns += [
         url(os.path.join(binder.root, r"$"), index, {"binder": binder}, name=binder.index_url_name),
         url(os.path.join(binder.root, r"(?P<slug>[^/]+)/$"), page, {"binder": binder}, name=binder.page_url_name),
         url(os.path.join(binder.root, r"(?P<slug>[^/]+)/edit/$"), edit, {"binder": binder}, name=binder.edit_url_name),
-    )
+    ]


### PR DESCRIPTION
django.conf.urls.patterns was removed in Django 1.10, after being deprecated in Django 1.8. Please see https://docs.djangoproject.com/en/1.8/ref/urls/#django.conf.urls.patterns
